### PR TITLE
Passando parâmetros exigidos na 3DS v2

### DIFF
--- a/src/Filipegar/eRede/Acquirer/ThreeDSecure.php
+++ b/src/Filipegar/eRede/Acquirer/ThreeDSecure.php
@@ -18,6 +18,8 @@ class ThreeDSecure implements \JsonSerializable
     private $redirectUrl;
     private $returnCode;
     private $returnMessage;
+    private $threeDIndicator;
+    private $DirectoryServerTransactionId;
 
     public static function fromJson($json)
     {
@@ -39,6 +41,8 @@ class ThreeDSecure implements \JsonSerializable
             $this->returnCode = isset($data->threeDSecure->returnCode) ? $data->threeDSecure->returnCode : null;
             $this->returnMessage = isset($data->threeDSecure->returnMessage) ? $data->threeDSecure->returnMessage
                 : null;
+            $this->threeDIndicator = isset($data->threeDSecure->threeDIndicator) ? $data->threeDSecure->threeDIndicator : null;
+            $this->DirectoryServerTransactionId = isset($data->threeDSecure->DirectoryServerTransactionId) ? $data->threeDSecure->DirectoryServerTransactionId : null;
         }
     }
 
@@ -184,6 +188,38 @@ class ThreeDSecure implements \JsonSerializable
     public function setReturnCode($returnCode)
     {
         $this->returnCode = $returnCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getThreeDIndicator()
+    {
+        return $this->threeDIndicator;
+    }
+
+    /**
+     * @param string $threeDIndicator
+     */
+    public function setThreeDIndicator($threeDIndicator)
+    {
+        $this->threeDIndicator = $threeDIndicator;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDirectoryServerTransactionId()
+    {
+        return $this->DirectoryServerTransactionId;
+    }
+
+    /**
+     * @param string $DirectoryServerTransactionId
+     */
+    public function setDirectoryServerTransactionId($DirectoryServerTransactionId)
+    {
+        $this->DirectoryServerTransactionId = $DirectoryServerTransactionId;
     }
 
     /**

--- a/src/Filipegar/eRede/Acquirer/Transaction.php
+++ b/src/Filipegar/eRede/Acquirer/Transaction.php
@@ -428,12 +428,14 @@ class Transaction implements \JsonSerializable, Requestable
         return $card;
     }
 
-    public function threeDSecure($mpi = ThreeDSecure::MPI_EREDE, $onFailure = ThreeDSecure::FAILURE_DECLINE)
+    public function threeDSecure($mpi = ThreeDSecure::MPI_EREDE, $onFailure = ThreeDSecure::FAILURE_DECLINE, $directoryServerTransactionId = "",  $threeDIndicator = "2")
     {
         $threeDScure = new ThreeDSecure();
 
         $threeDScure->setEmbedded($mpi);
         $threeDScure->setOnFailure($onFailure);
+        $threeDScure->setDirectoryServerTransactionId($directoryServerTransactionId);
+        $threeDScure->setThreeDIndicator($threeDIndicator);
         $this->setThreeDSecure($threeDScure);
 
         return $threeDScure;


### PR DESCRIPTION
Passando threeDIndicator e DirectoryServerTransactionId na threeDSecure, exigido na 3DS v2